### PR TITLE
Add Dockerfile for pfcp-kitchen-sink

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+# Exclude common files and directories
+.git
+.idea
+.vscode
+*.log
+*.md
+LICENSE
+README*
+.gitignore
+
+# Exclude build artifacts
+main
+bin/
+vendor/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# Use an official Go runtime as a parent image
+FROM golang:1.22-alpine AS builder
+
+# Set the working directory to /app
+WORKDIR /app
+
+# Install system packages
+RUN apk add --no-cache git
+    
+# Copy go mod and sum files
+COPY go.mod go.sum ./
+
+# Download all dependencies. Dependencies will be cached if the go.mod and go.sum files are not changed
+RUN go mod download
+
+# Install any required dependencies
+RUN go get -u -v github.com/alvaroloes/enumer && \
+    go install github.com/alvaroloes/enumer
+
+# Copy the current directory contents into the container at /app
+COPY . .
+
+# Generate Go files using `enumer` package
+RUN go generate ./pkg/pfcp
+
+# Build the executable
+RUN go build -o pfcpclient cmd/pfcpclient/main.go
+
+# Start a new stage for running the application
+FROM alpine:3.19 AS runtime
+
+WORKDIR /app
+
+# Copy the compiled binary from the builder stage
+COPY --from=builder /app/pfcpclient /app/
+
+# Expose port 8805 for the app to listen on
+EXPOSE 8805
+
+# Serve the app using CMD
+# CMD [ "/pfcpclient" ]


### PR DESCRIPTION
**The Changes:**
- Created a Dockerfile to build an image for the pfcp-kitchen-sink tool.
- Integrated pfcp-kitchen-sink into an existing OAI UPF Docker Compose setup.

**The Why:**

- Simplifies the integration of pfcp-kitchen-sink into environments using OAI UPF's Docker Compose configuration.
- Enhances ease of use and testing with pfcp-kitchen-sink in containerised settings.

**How to Test:**
- Build the pfcp-kitchen-sink image using the provided Dockerfile.
- Update your OAI UPF docker-compose.yml file to include the pfcp-kitchen-sink container (see sample below).
- Start the Docker Compose environment
- In the `tc-gtpu` container create setup a dummy interface for UE `./tc-gtpu -g eth0 -i uegtp -s 192.168.70.130 -d 192.168.70.134 -u 12.1.1.2 --ul-teid 1234 --dl-teid 1234 -q 9 -n 1 -f /home/tu-gtpu.pcap -vvv` and the send traffic `ping -I uegtp0 8.8.8.8 -c 5`

```yaml
version: '3.8'
services:
    pfcp-kitchen-sink:
        container_name: "pfcp-kitchen-sink"
        image: tariromukute/pfcp-kitchen-sink:latest
        volumes:
            - ./sessions-oai-upf.yaml:/app/sessions.yaml
        command: ./pfcpclient -r 192.168.70.134:8805 -s sessions.yaml
        depends_on:
            - oai-upf
        networks:
            public_net:
                ipv4_address: 192.168.70.131
    tc-gtpu:
        container_name: "tc-gtpu"
        image: tariromukute/tc-gtpu:latest
        command: tail -f /dev/null
        volumes:
            - /sys/kernel/debug/:/sys/kernel/debug/
        devices:
            - /dev/net/tun:/dev/net/tun
        cap_add:
            - NET_ADMIN
            - SYS_ADMIN
        depends_on:
            - oai-upf
            - pfcp-kitchen-sink
        networks:
            public_net:
                ipv4_address: 192.168.70.130
    oai-upf:
        container_name: "oai-upf"
        image: oaisoftwarealliance/oai-upf:develop
        volumes:
            - ./basic_config.yaml:/openair-upf/etc/config.yaml
        environment:
            - TZ=Europe/Paris
        cap_add:
            - NET_ADMIN
            - SYS_ADMIN
        cap_drop:
            - ALL
        privileged: true
        networks:
            public_net:
                ipv4_address: 192.168.70.134
            n6_net:
                ipv4_address: 192.168.72.134
    oai-ext-dn:
        privileged: true
        init: true
        container_name: "oai-ext-dn"
        image: oaisoftwarealliance/trf-gen-cn5g:latest
        entrypoint: /bin/bash -c \
              "iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE;"\
              "ip route add 12.1.1.0/24 via 192.168.72.134 dev eth0; ip route; sleep infinity"
        command: ["/bin/bash", "-c", "trap : SIGTERM SIGINT; sleep infinity & wait"]
        healthcheck:
            test: /bin/bash -c "iptables -L -t nat | grep MASQUERADE"
            interval: 10s
            timeout: 5s
            retries: 5
        networks:
            public_net:
                ipv4_address: 192.168.70.135
            n6_net:
                ipv4_address: 192.168.72.135
networks:
    public_net:
        driver: bridge
        name: demo-oai-public-net
        ipam:
            config:
                - subnet: 192.168.70.128/26
        driver_opts:
            com.docker.network.bridge.name: "demo-oai"
    n6_net:
        driver: bridge
        name: demo-oai-n6-net
        ipam:
            config:
                - subnet: 192.168.72.128/26
        driver_opts:
            com.docker.network.bridge.name: "demo-n6"
```